### PR TITLE
Modified close functionality of modal-box

### DIFF
--- a/mojaglobal-ui/src/components/ModalBox/ModalBox.vue
+++ b/mojaglobal-ui/src/components/ModalBox/ModalBox.vue
@@ -1,5 +1,6 @@
 <template>
-    <div class="box-wrapper box-alert-mask" @click="toggle">
+    <div class="box-wrapper box-alert-mask modal-common">
+        <div class="dark modal-common" @click="toggle"></div>
         <div class="box-alert-wrapper">
             <slot></slot>
         </div>
@@ -12,7 +13,7 @@
         components: {
         },
         props: {
-            toggle: { type: Function ,required:true},
+            toggle: { type: Function,required: true },
         }
     }
 
@@ -20,20 +21,27 @@
 
 <style scoped>
     .box-wrapper {
+        z-index: 1;
+    }
+
+    .modal-common {
         width: 100%;
         height: 100%;
         min-height: 100%;
         display: flex;
         flex-direction: column;
         align-items: center;
-        justify-content:center
+        justify-content: center;
     }
 
-    
+    .dark {
+        z-index: -1;
+        position: fixed;
+        cursor: pointer;
+    }
 
     .box-alert-mask {
         position: fixed;
-        z-index: 9999;
         top: 0;
         left: 0;
         width: 100%;


### PR DESCRIPTION
While integrating the modal box in the map of FLINT.UI, I realized that it is closing even if we click on card content. Now it would only close by clicking on the gray area!

Fixes #37 

https://user-images.githubusercontent.com/55620053/184736274-a45cab2f-8c88-4d33-a565-0341da26bebb.mp4